### PR TITLE
Refactor - move data related functionality to separate files

### DIFF
--- a/config/package-solution.json
+++ b/config/package-solution.json
@@ -3,7 +3,7 @@
   "solution": {
     "name": "k-2-api-webpart-client-side-solution",
     "id": "4f7c70d3-2fa3-4b59-8c92-3e19938e250c",
-    "version": "1.0.0.2",
+    "version": "1.0.0.3",
     "includeClientSideAssets": true,
     "webApiPermissionRequests": [
       {

--- a/src/webparts/k2ApiWebPart/K2DataContracts.ts
+++ b/src/webparts/k2ApiWebPart/K2DataContracts.ts
@@ -1,0 +1,16 @@
+
+export interface IK2Worklist {
+    itemCount: string;
+    tasks: IK2Task[];
+}
+
+export interface IK2Task {
+    serialNumber: string;
+    formURL: string;
+    viewFlowURL: string;
+    workflowDisplayName: string;
+    workflowInstanceID: number;
+    workflowInstanceFolio: string;
+    activityName: string;
+
+}

--- a/src/webparts/k2ApiWebPart/K2DataReader.ts
+++ b/src/webparts/k2ApiWebPart/K2DataReader.ts
@@ -1,0 +1,21 @@
+import { IWebPartContext } from '@microsoft/sp-webpart-base';
+
+import { AadHttpClient, HttpClientResponse} from '@microsoft/sp-http';
+
+import {IK2Worklist} from './K2DataContracts';
+
+export class K2DataReader {
+    private  _aadClient: AadHttpClient;
+
+    constructor(aadClient: AadHttpClient) {
+       this._aadClient = aadClient;
+    }
+
+    public getData(k2ServerURL): Promise<IK2Worklist> {
+        return this._aadClient.get(k2ServerURL + '/api/workflow/preview/tasks', AadHttpClient.configurations.v1)
+        .then((res: HttpClientResponse): Promise<any> => {          
+          return res.json();
+        });
+    }
+}
+

--- a/src/webparts/k2ApiWebPart/K2DataView.ts
+++ b/src/webparts/k2ApiWebPart/K2DataView.ts
@@ -1,0 +1,29 @@
+import {IK2Worklist} from './K2DataContracts';
+
+import styles from './K2ApiWebPartWebPart.module.scss';
+
+
+export class K2DataView {
+
+    public static getWorklistHtml(worklist: IK2Worklist) {
+        var html = '';
+
+        html = `
+<div class="${ styles.k2ApiWebPart }">
+
+<div class="${ styles.row }">
+<div class="${ styles.column }">
+  <span class="${ styles.title }">K2 Worklist</span>
+  </div>
+  </div>
+        <table>
+        <tr class="ms-Grid-row"><th class="ms-Grid-col ms-u-sm5 ms-u-md3 ms-u-lg2 ms-bgColor-themeLight  ms-font-m-plus">Form URL</th><th class="ms-Grid-col ms-u-sm5 ms-u-md3 ms-u-lg3 ms-bgColor-themeLight  ms-font-m-plus">Workflow Name</th><th class="ms-Grid-col ms-u-sm5 ms-u-md3 ms-u-lg3 ms-bgColor-themeLight  ms-font-m-plus">Folio</th><th class="ms-Grid-col ms-u-sm5 ms-u-md3 ms-u-lg2 ms-bgColor-themeLight  ms-font-m-plus">Activity</th><th class="ms-Grid-col ms-u-sm5 ms-u-md3 ms-u-lg2 ms-bgColor-themeLight  ms-font-m-plus">Viewflow</th></tr>
+        ${worklist.tasks.map(t => `<tr class="ms-Grid-row"><td class="ms-Grid-col ms-u-sm5 ms-u-md3 ms-u-lg2 ms-font-m"><a href="${t.formURL}" target="_blank" class="${ styles.button }">Open Form</a></td><td class="ms-Grid-col ms-u-sm5 ms-u-md3 ms-u-lg3 ms-font-m">${t.workflowDisplayName}</td><td class="ms-Grid-col ms-u-sm5 ms-u-md3 ms-u-lg3 ms-font-m">${t.workflowInstanceFolio}</td><td class="ms-Grid-col ms-u-sm5 ms-u-md3 ms-u-lg2 ms-font-m">${t.activityName}</td><td class="ms-Grid-col ms-u-sm5 ms-u-md3 ms-u-lg2 ms-font-m"><a href="${t.viewFlowURL}" target="_blank">View</a></td>`).join('')}
+        </table>
+        <p>Available tasks: ${worklist.itemCount} in total</p>
+       
+
+</div>`;
+        return html;
+    }
+}


### PR DESCRIPTION
Extract API call, data model and view composition to separate files to clean up main webpart code file and attempt to separate concerns, inspired by https://code.msdn.microsoft.com/office/SOLID-Web-Parts-with-8288d88a and https://www.youtube.com/watch?v=_kHsSXr6_ys&index=11&list=PLMLjnY5iPR3VlkcOux77kOI9LxLZu14gQ